### PR TITLE
Check improvments

### DIFF
--- a/examples/java-application/src/main/java/com/aserto/example/PathObjectIdMapper.java
+++ b/examples/java-application/src/main/java/com/aserto/example/PathObjectIdMapper.java
@@ -1,0 +1,26 @@
+package com.aserto.example;
+
+import com.aserto.authroizer.mapper.object.ObjectIdMapper;
+import jakarta.servlet.http.HttpServletRequest;
+import org.springframework.stereotype.Component;
+import org.springframework.web.servlet.HandlerMapping;
+
+import java.util.Map;
+
+
+@Component("objIdMapper")
+public class PathObjectIdMapper implements ObjectIdMapper {
+//    private String id;
+//
+//    public PathObjectIdMapper setId(String id) {
+//        this.id = id;
+//        return this;
+//    }
+
+    @Override
+    public String getValue(HttpServletRequest httpRequest) {
+        Map<String, String> pathAttributes = (Map<String, String>)httpRequest.getAttribute(HandlerMapping.URI_TEMPLATE_VARIABLES_ATTRIBUTE);
+        return pathAttributes.get("id");
+//        return id;
+    }
+}

--- a/examples/java-application/src/main/java/com/aserto/example/PathObjectIdMapper.java
+++ b/examples/java-application/src/main/java/com/aserto/example/PathObjectIdMapper.java
@@ -1,6 +1,6 @@
 package com.aserto.example;
 
-import com.aserto.authroizer.mapper.object.ObjectIdMapper;
+import com.aserto.authroizer.mapper.check.object.ObjectIdMapper;
 import jakarta.servlet.http.HttpServletRequest;
 import org.springframework.stereotype.Component;
 import org.springframework.web.servlet.HandlerMapping;

--- a/examples/java-application/src/main/java/com/aserto/example/PathObjectIdMapper.java
+++ b/examples/java-application/src/main/java/com/aserto/example/PathObjectIdMapper.java
@@ -10,17 +10,16 @@ import java.util.Map;
 
 @Component("objIdMapper")
 public class PathObjectIdMapper implements ObjectIdMapper {
-//    private String id;
-//
-//    public PathObjectIdMapper setId(String id) {
-//        this.id = id;
-//        return this;
-//    }
+    private String attributeName;
+
+    public PathObjectIdMapper fromAttribute(String attributeName) {
+        this.attributeName = attributeName;
+        return this;
+    }
 
     @Override
     public String getValue(HttpServletRequest httpRequest) {
         Map<String, String> pathAttributes = (Map<String, String>)httpRequest.getAttribute(HandlerMapping.URI_TEMPLATE_VARIABLES_ATTRIBUTE);
-        return pathAttributes.get("id");
-//        return id;
+        return pathAttributes.get(attributeName);
     }
 }

--- a/examples/java-application/src/main/java/com/aserto/example/controller/GenericController.java
+++ b/examples/java-application/src/main/java/com/aserto/example/controller/GenericController.java
@@ -6,12 +6,11 @@ import org.springframework.web.bind.annotation.*;
 @RestController
 public class GenericController {
     @DeleteMapping("/todos/{id}")
-//    @PreAuthorize("@check('group', new com.aserto.example.PathObjectIdMapper(#id), 'member')")
-//    @PreAuthorize("@check('group', @objIdMapper, 'member')")
-//    @PreAuthorize("@check('group', #id, 'member')")
-//    @PreAuthorize("@check.objectType('group').objectId(#id).relation('member').allowed()")
-    @PreAuthorize("@check.objectId(#id).relation('member').allowed()")
-//    @PreAuthorize("@check.objectType('group').objectId('admin').relation('member').allowed()")
+//    @PreAuthorize("@check.objectType('group').objectId(new com.aserto.example.PathObjectIdMapper().fromAttribute('id')).relation('member').allowed()")    // we use a custom mapper that extracts the id from the path params
+//    @PreAuthorize("@check.objectType('group').objectId(@objIdMapper.fromAttribute('id')).relation('member').allowed()")   // we use a custom mapper that extracts the id from the path params
+//    @PreAuthorize("@check.objectType('group').objectId(#id).relation('member').allowed()")            // objectId is set to the id variable
+//    @PreAuthorize("@check.objectId(#id).relation('member').allowed()")                                // this should throw an exception as no objectType is set
+    @PreAuthorize("@check.objectType('group').objectId('admin').relation('member').allowed()")        // static objectId
     public String deleteTodo(@PathVariable String id) {
         return "Hello from route DELETE /todos/{" + id + "}";
     }

--- a/examples/java-application/src/main/java/com/aserto/example/controller/GenericController.java
+++ b/examples/java-application/src/main/java/com/aserto/example/controller/GenericController.java
@@ -6,31 +6,35 @@ import org.springframework.web.bind.annotation.*;
 @RestController
 public class GenericController {
     @DeleteMapping("/todos/{id}")
-    @PreAuthorize("@aserto.check('group', 'admin', 'member')")
+//    @PreAuthorize("@check('group', new com.aserto.example.PathObjectIdMapper(#id), 'member')")
+//    @PreAuthorize("@check('group', @objIdMapper, 'member')")
+//    @PreAuthorize("@check('group', #id, 'member')")
+    @PreAuthorize("@check.objectType('group').objectId(#id).relation('member').allowed()")
+//    @PreAuthorize("@check.objectType('group').objectId('admin').relation('member').allowed()")
     public String deleteTodo(@PathVariable String id) {
         return "Hello from route DELETE /todos/{" + id + "}";
     }
 
     @GetMapping("/todos")
-    @PreAuthorize("@aserto.check('group', 'viewer', 'member')")
+    @PreAuthorize("@check.objectType('group').objectId('viewer').relation('member').allowed()")
     public String getTodo() {
         return "Hello from route GET /todos";
     }
 
     @GetMapping("/users/{userID}")
-    @PreAuthorize("@aserto.check('group', 'viewer', 'member')")
+    @PreAuthorize("@check.objectType('group').objectId('viewer').relation('member').allowed()")
     public String getUsers(@PathVariable String userID) {
         return "Hello from route GET /users/{" + userID + "}";
     }
 
     @PostMapping("/todos")
-    @PreAuthorize("@aserto.check('group', 'editor', 'member')")
+    @PreAuthorize("@check.objectType('group').objectId('editor').relation('member').allowed()")
     public String postTodo() {
         return "Hello from route POST /todos";
     }
 
     @PutMapping("/todos/{id}")
-    @PreAuthorize("@aserto.check('group', 'editor', 'member')")
+    @PreAuthorize("@check.objectType('group').objectId('editor').relation('member').allowed()")
     public String putTodo(@PathVariable String id) {
         return "Hello from route PUT /todos/{" + id + "}";
     }

--- a/examples/java-application/src/main/java/com/aserto/example/controller/GenericController.java
+++ b/examples/java-application/src/main/java/com/aserto/example/controller/GenericController.java
@@ -9,7 +9,8 @@ public class GenericController {
 //    @PreAuthorize("@check('group', new com.aserto.example.PathObjectIdMapper(#id), 'member')")
 //    @PreAuthorize("@check('group', @objIdMapper, 'member')")
 //    @PreAuthorize("@check('group', #id, 'member')")
-    @PreAuthorize("@check.objectType('group').objectId(#id).relation('member').allowed()")
+//    @PreAuthorize("@check.objectType('group').objectId(#id).relation('member').allowed()")
+    @PreAuthorize("@check.objectId(#id).relation('member').allowed()")
 //    @PreAuthorize("@check.objectType('group').objectId('admin').relation('member').allowed()")
     public String deleteTodo(@PathVariable String id) {
         return "Hello from route DELETE /todos/{" + id + "}";

--- a/examples/java-application/src/main/java/com/aserto/example/controller/GenericController.java
+++ b/examples/java-application/src/main/java/com/aserto/example/controller/GenericController.java
@@ -6,7 +6,7 @@ import org.springframework.web.bind.annotation.*;
 @RestController
 public class GenericController {
     @DeleteMapping("/todos/{id}")
-//    @PreAuthorize("@check.objectType('group').objectId(new com.aserto.example.PathObjectIdMapper().fromAttribute('id')).relation('member').allowed()")    // we use a custom mapper that extracts the id from the path params
+//    @PreAuthorize("@check.objectType('group').objectId(new com.aserto.example.mapper.PathObjectIdMapper().fromAttribute('id')).relation('member').allowed()")    // we use a custom mapper that extracts the id from the path params
 //    @PreAuthorize("@check.objectType('group').objectId(@objIdMapper.fromAttribute('id')).relation('member').allowed()")   // we use a custom mapper that extracts the id from the path params
 //    @PreAuthorize("@check.objectType('group').objectId(#id).relation('member').allowed()")            // objectId is set to the id variable
 //    @PreAuthorize("@check.objectId(#id).relation('member').allowed()")                                // this should throw an exception as no objectType is set

--- a/examples/java-application/src/main/java/com/aserto/example/mapper/PathObjectIdMapper.java
+++ b/examples/java-application/src/main/java/com/aserto/example/mapper/PathObjectIdMapper.java
@@ -1,4 +1,4 @@
-package com.aserto.example;
+package com.aserto.example.mapper;
 
 import com.aserto.authroizer.mapper.check.object.ObjectIdMapper;
 import jakarta.servlet.http.HttpServletRequest;

--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
 
 	<groupId>com.aserto</groupId>
 	<artifactId>aserto-spring</artifactId>
-	<version>0.0.12</version>
+	<version>0.0.13</version>
 
 	<name>spring-middleware</name>
 	<description>Spring Security Filter that enables Aserto authorization</description>
@@ -64,20 +64,20 @@
 		<dependency>
 			<groupId>com.nimbusds</groupId>
 			<artifactId>nimbus-jose-jwt</artifactId>
-			<version>9.37</version>
+			<version>9.37.3</version>
 		</dependency>
 
 		<!-- use to convert json to proto -->
 		<dependency>
 			<groupId>com.google.protobuf</groupId>
 			<artifactId>protobuf-java-util</artifactId>
-			<version>3.24.4</version>
+			<version>3.25.1</version>
 		</dependency>
 
 		<dependency>
 			<groupId>com.aserto</groupId>
 			<artifactId>aserto-java</artifactId>
-			<version>0.20.9</version>
+			<version>0.20.11</version>
 		</dependency>
 
 		<dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -77,7 +77,7 @@
 		<dependency>
 			<groupId>com.aserto</groupId>
 			<artifactId>aserto-java</artifactId>
-			<version>0.20.11</version>
+			<version>0.21.1</version>
 		</dependency>
 
 		<dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
 
 	<groupId>com.aserto</groupId>
 	<artifactId>aserto-spring</artifactId>
-	<version>0.0.13</version>
+	<version>0.1.0</version>
 
 	<name>spring-middleware</name>
 	<description>Spring Security Filter that enables Aserto authorization</description>

--- a/src/main/java/com/aserto/authroizer/AsertoAuthorizationManager.java
+++ b/src/main/java/com/aserto/authroizer/AsertoAuthorizationManager.java
@@ -31,13 +31,13 @@ public final class AsertoAuthorizationManager implements AuthorizationManager<Re
     private String policyName;
     private String policyLabel;
     boolean authorizerEnabled;
-    private IdentityMapper identityMapper;
+    private IdentityMapper configIdentityMapper;
     private PolicyMapper configPolicyMapper;
     private ResourceMapper configResourceMapper;
     private AuthorizerClient authzClient;
 
     public AsertoAuthorizationManager(AuthzConfig authzConfig) {
-        this.identityMapper = authzConfig.getIdentityMapper();
+        this.configIdentityMapper = authzConfig.getIdentityMapper();
         this.configPolicyMapper = authzConfig.getPolicyMapper();
         this.configResourceMapper = authzConfig.getResourceMapper();
         this.authzClient = authzConfig.getAuthzClient();
@@ -80,6 +80,19 @@ public final class AsertoAuthorizationManager implements AuthorizationManager<Re
      * @return true if the user is authorized, false otherwise
      */
     public AuthorizationDecision check(HttpServletRequest httpRequest, PolicyMapper policyMapper, ResourceMapper resourceMapper) {
+        return this.check(httpRequest, configIdentityMapper, policyMapper, resourceMapper);
+    }
+
+    /*
+     * Check if the current user is authorized to perform the action defined in the policy.
+     *
+     * @param httpRequest The http request
+     * @param identityMapper The identity mapper
+     * @param policyMapper The policy mapper
+     * @param resourceMapper The resource mapper
+     * @return true if the user is authorized, false otherwise
+     */
+    public AuthorizationDecision check(HttpServletRequest httpRequest, IdentityMapper identityMapper, PolicyMapper policyMapper, ResourceMapper resourceMapper) {
         if (!authorizerEnabled) {
             return new AuthorizationDecision(true);
         }

--- a/src/main/java/com/aserto/authroizer/CheckConfig.java
+++ b/src/main/java/com/aserto/authroizer/CheckConfig.java
@@ -1,12 +1,12 @@
 package com.aserto.authroizer;
 
-import com.aserto.authroizer.mapper.object.ObjectIdMapper;
-import com.aserto.authroizer.mapper.object.ObjectTypeMapper;
-import com.aserto.authroizer.mapper.object.StaticObjectIdMapper;
-import com.aserto.authroizer.mapper.object.StaticObjectTypeMapper;
-import com.aserto.authroizer.mapper.relation.RelationMapper;
+import com.aserto.authroizer.mapper.check.object.ObjectIdMapper;
+import com.aserto.authroizer.mapper.check.object.ObjectTypeMapper;
+import com.aserto.authroizer.mapper.check.object.StaticObjectIdMapper;
+import com.aserto.authroizer.mapper.check.object.StaticObjectTypeMapper;
+import com.aserto.authroizer.mapper.check.relation.RelationMapper;
 import com.aserto.authroizer.mapper.policy.StaticPolicyMapper;
-import com.aserto.authroizer.mapper.relation.StaticRelationMapper;
+import com.aserto.authroizer.mapper.check.relation.StaticRelationMapper;
 import com.aserto.authroizer.mapper.resource.CheckResourceMapper;
 
 public class CheckConfig {

--- a/src/main/java/com/aserto/authroizer/DefaultMappers.java
+++ b/src/main/java/com/aserto/authroizer/DefaultMappers.java
@@ -1,7 +1,7 @@
 package com.aserto.authroizer;
 
 import com.aserto.AuthorizerClient;
-import com.aserto.AuthzClient;
+import com.aserto.authorizer.AuthzClient;
 import com.aserto.ChannelBuilder;
 import com.aserto.authroizer.config.loader.spring.AuhorizerLoader;
 import com.aserto.authroizer.mapper.identity.IdentityMapper;

--- a/src/main/java/com/aserto/authroizer/MethodAuthorization.java
+++ b/src/main/java/com/aserto/authroizer/MethodAuthorization.java
@@ -2,8 +2,11 @@ package com.aserto.authroizer;
 
 import com.aserto.authroizer.mapper.object.ObjectIdMapper;
 import com.aserto.authroizer.mapper.object.ObjectTypeMapper;
+import com.aserto.authroizer.mapper.object.StaticObjectIdMapper;
+import com.aserto.authroizer.mapper.object.StaticObjectTypeMapper;
 import com.aserto.authroizer.mapper.relation.RelationMapper;
 import com.aserto.authroizer.mapper.policy.StaticPolicyMapper;
+import com.aserto.authroizer.mapper.relation.StaticRelationMapper;
 import com.aserto.authroizer.mapper.resource.CheckResourceMapper;
 import jakarta.servlet.http.HttpServletRequest;
 import org.springframework.security.authorization.AuthorizationDecision;
@@ -13,10 +16,13 @@ import org.springframework.stereotype.Component;
 * This class provides methods to check if the current user is authorized to perform an action.
 * It can be used for method level authorization.
  */
-@Component("aserto")
+@Component("check")
 class MethodAuthorization {
     private AsertoAuthorizationManager asertoAuthzManager;
     private HttpServletRequest httpRequest;
+    private ObjectTypeMapper objectTypeMapper;
+    private ObjectIdMapper objectIdMapper;
+    private RelationMapper relationMapper;
 
     public MethodAuthorization(AuthzConfig authzCfg, HttpServletRequest httpRequest) {
         asertoAuthzManager = new AsertoAuthorizationManager(authzCfg);
@@ -24,42 +30,80 @@ class MethodAuthorization {
     }
 
 
-    /*
-    * Check if the current user is authorized to perform the action defined in the policy.
-    * @return true if the user is authorized, false otherwise
-     */
-    public boolean check() {
-        AuthorizationDecision decision = asertoAuthzManager.check(httpRequest);
-        return decision.isGranted();
+//    /*
+//    * Check if the current user is authorized to perform the action defined in the policy.
+//    * @return true if the user is authorized, false otherwise
+//     */
+//    public boolean check() {
+//        AuthorizationDecision decision = asertoAuthzManager.check(httpRequest);
+//        return decision.isGranted();
+//    }
+//
+//    /*
+//    * Check if the current user has a relation to the object defined by ObjectType, ObjectId and Relation.
+//    * If the relation exists, the user is authorized.
+//    *
+//    * @param objectType The type of the object
+//    * @param objectId The id of the object
+//    * @param relation The relation to check
+//    * @return true if the user is authorized, false otherwise
+//     */
+//    public boolean check(String objectType, String objectId, String relation) {
+//        StaticPolicyMapper policyMapper = new StaticPolicyMapper("rebac.check");
+//        CheckResourceMapper checkResourceMapper = new CheckResourceMapper(objectType, objectId, relation);
+//
+//        AuthorizationDecision decision = asertoAuthzManager.check(httpRequest, policyMapper, checkResourceMapper);
+//        return decision.isGranted();
+//    }
+//
+//    /*
+//     * Check if the current user has a relation to the object defined by objectTypeMapper, ObjectIdMapper and RelationMapper.
+//     * If the relation exists, the user is authorized.
+//     *
+//     * @param objectTypeMapper The mapper for the type of the object
+//     * @param objectIdMapper The mapper for the id of the object
+//     * @param relationMapper The mapper for the relation to check
+//     * @return true if the user is authorized, false otherwise
+//     */
+//    public boolean check(ObjectTypeMapper objectTypeMapper, ObjectIdMapper objectIdMapper, RelationMapper relationMapper) {
+//        StaticPolicyMapper policyMapper = new StaticPolicyMapper("rebac.check");
+//        CheckResourceMapper checkResourceMapper = new CheckResourceMapper(objectTypeMapper, objectIdMapper, relationMapper);
+//
+//        AuthorizationDecision decision = asertoAuthzManager.check(httpRequest, policyMapper, checkResourceMapper);
+//        return decision.isGranted();
+//    }
+
+    public MethodAuthorization objectType(String objectType) {
+        objectTypeMapper = new StaticObjectTypeMapper(objectType);
+        return this;
     }
 
-    /*
-    * Check if the current user has a relation to the object defined by ObjectType, ObjectId and Relation.
-    * If the relation exists, the user is authorized.
-    *
-    * @param objectType The type of the object
-    * @param objectId The id of the object
-    * @param relation The relation to check
-    * @return true if the user is authorized, false otherwise
-     */
-    public boolean check(String objectType, String objectId, String relation) {
-        StaticPolicyMapper policyMapper = new StaticPolicyMapper("rebac.check");
-        CheckResourceMapper checkResourceMapper = new CheckResourceMapper(objectType, objectId, relation);
-
-        AuthorizationDecision decision = asertoAuthzManager.check(httpRequest, policyMapper, checkResourceMapper);
-        return decision.isGranted();
+    public MethodAuthorization objectType(ObjectTypeMapper objectTypeMapper) {
+        this.objectTypeMapper = objectTypeMapper;
+        return this;
     }
 
-    /*
-     * Check if the current user has a relation to the object defined by objectTypeMapper, ObjectIdMapper and RelationMapper.
-     * If the relation exists, the user is authorized.
-     *
-     * @param objectTypeMapper The mapper for the type of the object
-     * @param objectIdMapper The mapper for the id of the object
-     * @param relationMapper The mapper for the relation to check
-     * @return true if the user is authorized, false otherwise
-     */
-    public boolean check(ObjectTypeMapper objectTypeMapper, ObjectIdMapper objectIdMapper, RelationMapper relationMapper) {
+    public MethodAuthorization objectId(String objectId) {
+        objectIdMapper = new StaticObjectIdMapper(objectId);
+        return this;
+    }
+
+    public MethodAuthorization objectId(ObjectIdMapper objectId) {
+        this.objectIdMapper = objectId;
+        return this;
+    }
+
+    public MethodAuthorization relation(String relation) {
+        relationMapper = new StaticRelationMapper(relation);
+        return this;
+    }
+
+    public MethodAuthorization relation(RelationMapper relation) {
+        this.relationMapper = relation;
+        return this;
+    }
+
+    public boolean allowed() {
         StaticPolicyMapper policyMapper = new StaticPolicyMapper("rebac.check");
         CheckResourceMapper checkResourceMapper = new CheckResourceMapper(objectTypeMapper, objectIdMapper, relationMapper);
 

--- a/src/main/java/com/aserto/authroizer/MethodAuthorization.java
+++ b/src/main/java/com/aserto/authroizer/MethodAuthorization.java
@@ -90,10 +90,10 @@ class MethodAuthorization {
         validateFields();
 
         StaticPolicyMapper policyMapper = new StaticPolicyMapper("rebac.check");
-        CheckResourceMapper checkResourceMapper = new CheckResourceMapper(objectTypeMapper, objectIdMapper, relationMapper);
+        CheckResourceMapper checkResourceMapper = new CheckResourceMapper(objectTypeMapper, objectIdMapper, relationMapper, subjectTypeMapper);
 
         AuthorizationDecision decision;
-        if (subjectIdMapper != null) {
+        if (subjectIdMapper != null && subjectTypeMapper != null) {
             ManualIdentityMapper identityMapper = new ManualIdentityMapper(subjectIdMapper.getValue(httpRequest));
             decision = asertoAuthzManager.check(httpRequest, identityMapper, policyMapper, checkResourceMapper);
         } else {

--- a/src/main/java/com/aserto/authroizer/mapper/check/object/ObjectIdMapper.java
+++ b/src/main/java/com/aserto/authroizer/mapper/check/object/ObjectIdMapper.java
@@ -1,7 +1,7 @@
-package com.aserto.authroizer.mapper.object;
+package com.aserto.authroizer.mapper.check.object;
 
 import jakarta.servlet.http.HttpServletRequest;
 
-public interface ObjectTypeMapper {
+public interface ObjectIdMapper {
     public String getValue(HttpServletRequest httpRequest);
 }

--- a/src/main/java/com/aserto/authroizer/mapper/check/object/ObjectTypeMapper.java
+++ b/src/main/java/com/aserto/authroizer/mapper/check/object/ObjectTypeMapper.java
@@ -1,7 +1,7 @@
-package com.aserto.authroizer.mapper.object;
+package com.aserto.authroizer.mapper.check.object;
 
 import jakarta.servlet.http.HttpServletRequest;
 
-public interface ObjectIdMapper {
+public interface ObjectTypeMapper {
     public String getValue(HttpServletRequest httpRequest);
 }

--- a/src/main/java/com/aserto/authroizer/mapper/check/object/StaticObjectIdMapper.java
+++ b/src/main/java/com/aserto/authroizer/mapper/check/object/StaticObjectIdMapper.java
@@ -1,4 +1,4 @@
-package com.aserto.authroizer.mapper.object;
+package com.aserto.authroizer.mapper.check.object;
 
 import jakarta.servlet.http.HttpServletRequest;
 

--- a/src/main/java/com/aserto/authroizer/mapper/check/object/StaticObjectTypeMapper.java
+++ b/src/main/java/com/aserto/authroizer/mapper/check/object/StaticObjectTypeMapper.java
@@ -1,4 +1,4 @@
-package com.aserto.authroizer.mapper.object;
+package com.aserto.authroizer.mapper.check.object;
 
 import jakarta.servlet.http.HttpServletRequest;
 

--- a/src/main/java/com/aserto/authroizer/mapper/check/relation/RelationMapper.java
+++ b/src/main/java/com/aserto/authroizer/mapper/check/relation/RelationMapper.java
@@ -1,0 +1,7 @@
+package com.aserto.authroizer.mapper.check.relation;
+
+import jakarta.servlet.http.HttpServletRequest;
+
+public interface RelationMapper {
+    public String getValue(HttpServletRequest httpRequest);
+}

--- a/src/main/java/com/aserto/authroizer/mapper/check/relation/StaticRelationMapper.java
+++ b/src/main/java/com/aserto/authroizer/mapper/check/relation/StaticRelationMapper.java
@@ -1,4 +1,4 @@
-package com.aserto.authroizer.mapper.relation;
+package com.aserto.authroizer.mapper.check.relation;
 
 import jakarta.servlet.http.HttpServletRequest;
 

--- a/src/main/java/com/aserto/authroizer/mapper/check/subject/StaticSubjectIdMapper.java
+++ b/src/main/java/com/aserto/authroizer/mapper/check/subject/StaticSubjectIdMapper.java
@@ -1,0 +1,16 @@
+package com.aserto.authroizer.mapper.check.subject;
+
+import jakarta.servlet.http.HttpServletRequest;
+
+public class StaticSubjectIdMapper implements SubjectIdMapper {
+    private String subjectId;
+
+    public StaticSubjectIdMapper(String subjectId) {
+        this.subjectId = subjectId;
+    }
+
+    @Override
+    public String getValue(HttpServletRequest httpRequest) {
+        return subjectId;
+    }
+}

--- a/src/main/java/com/aserto/authroizer/mapper/check/subject/StaticSubjectTypeMapper.java
+++ b/src/main/java/com/aserto/authroizer/mapper/check/subject/StaticSubjectTypeMapper.java
@@ -1,0 +1,16 @@
+package com.aserto.authroizer.mapper.check.subject;
+
+import jakarta.servlet.http.HttpServletRequest;
+
+public class StaticSubjectTypeMapper implements SubjectTypeMapper {
+    private String subjectType;
+
+    public StaticSubjectTypeMapper(String subjectType) {
+        this.subjectType = subjectType;
+    }
+
+    @Override
+    public String getValue(HttpServletRequest httpRequest) {
+        return subjectType;
+    }
+}

--- a/src/main/java/com/aserto/authroizer/mapper/check/subject/SubjectIdMapper.java
+++ b/src/main/java/com/aserto/authroizer/mapper/check/subject/SubjectIdMapper.java
@@ -1,0 +1,7 @@
+package com.aserto.authroizer.mapper.check.subject;
+
+import jakarta.servlet.http.HttpServletRequest;
+
+public interface SubjectIdMapper {
+    public String getValue(HttpServletRequest httpRequest);
+}

--- a/src/main/java/com/aserto/authroizer/mapper/check/subject/SubjectTypeMapper.java
+++ b/src/main/java/com/aserto/authroizer/mapper/check/subject/SubjectTypeMapper.java
@@ -1,7 +1,7 @@
-package com.aserto.authroizer.mapper.relation;
+package com.aserto.authroizer.mapper.check.subject;
 
 import jakarta.servlet.http.HttpServletRequest;
 
-public interface RelationMapper {
+public interface SubjectTypeMapper {
     public String getValue(HttpServletRequest httpRequest);
 }

--- a/src/main/java/com/aserto/authroizer/mapper/identity/ManualIdentityMapper.java
+++ b/src/main/java/com/aserto/authroizer/mapper/identity/ManualIdentityMapper.java
@@ -1,0 +1,17 @@
+package com.aserto.authroizer.mapper.identity;
+
+import com.aserto.authorizer.v2.api.IdentityType;
+import com.aserto.model.IdentityCtx;
+import jakarta.servlet.http.HttpServletRequest;
+
+public class ManualIdentityMapper implements IdentityMapper {
+    private String identity;
+    public ManualIdentityMapper(String identity) {
+        this.identity = identity;
+    }
+
+    @Override
+    public IdentityCtx getIdentity(HttpServletRequest request) throws InvalidIdentity {
+        return new IdentityCtx(identity, IdentityType.IDENTITY_TYPE_MANUAL);
+    }
+}

--- a/src/main/java/com/aserto/authroizer/mapper/identity/ManualIdentityMapper.java
+++ b/src/main/java/com/aserto/authroizer/mapper/identity/ManualIdentityMapper.java
@@ -5,7 +5,7 @@ import com.aserto.model.IdentityCtx;
 import jakarta.servlet.http.HttpServletRequest;
 
 public class ManualIdentityMapper implements IdentityMapper {
-    private String identity;
+    private final String identity;
     public ManualIdentityMapper(String identity) {
         this.identity = identity;
     }

--- a/src/main/java/com/aserto/authroizer/mapper/resource/CheckResourceMapper.java
+++ b/src/main/java/com/aserto/authroizer/mapper/resource/CheckResourceMapper.java
@@ -6,6 +6,7 @@ import com.aserto.authroizer.mapper.check.object.StaticObjectIdMapper;
 import com.aserto.authroizer.mapper.check.object.StaticObjectTypeMapper;
 import com.aserto.authroizer.mapper.check.relation.RelationMapper;
 import com.aserto.authroizer.mapper.check.relation.StaticRelationMapper;
+import com.aserto.authroizer.mapper.check.subject.SubjectTypeMapper;
 import com.google.protobuf.Value;
 import jakarta.servlet.http.HttpServletRequest;
 
@@ -16,6 +17,8 @@ public class CheckResourceMapper implements ResourceMapper {
     private ObjectTypeMapper objectTypeMapper;
     private ObjectIdMapper objectIdMapper;
     private RelationMapper relationMapper;
+
+    private SubjectTypeMapper subjectTypeMapper;
 
     public CheckResourceMapper(String objectType, String objectId, String relation) {
         this.objectTypeMapper = new StaticObjectTypeMapper(objectType);
@@ -29,12 +32,24 @@ public class CheckResourceMapper implements ResourceMapper {
         this.relationMapper = relationMapper;
     }
 
+    public CheckResourceMapper(ObjectTypeMapper objectTypeMapper, ObjectIdMapper objectIdMapper, RelationMapper relationMapper, SubjectTypeMapper subjectTypeMapper) {
+        this.objectTypeMapper = objectTypeMapper;
+        this.objectIdMapper = objectIdMapper;
+        this.relationMapper = relationMapper;
+        this.subjectTypeMapper = subjectTypeMapper;
+    }
+
     @Override
     public Map<String, Value> getResource(HttpServletRequest request) throws ResourceMapperError {
         Map<String, Value> resourceCtx = new HashMap<>();
         resourceCtx.put("object_type", Value.newBuilder().setStringValue(objectTypeMapper.getValue(request)).build());
         resourceCtx.put("object_id", Value.newBuilder().setStringValue(objectIdMapper.getValue(request)).build());
         resourceCtx.put("relation", Value.newBuilder().setStringValue(relationMapper.getValue(request)).build());
+
+        // Subject type is optional and is used when identity Manual is provided
+        if (subjectTypeMapper != null) {
+            resourceCtx.put("subject_type", Value.newBuilder().setStringValue(subjectTypeMapper.getValue(request)).build());
+        }
 
         return resourceCtx;
     }

--- a/src/main/java/com/aserto/authroizer/mapper/resource/CheckResourceMapper.java
+++ b/src/main/java/com/aserto/authroizer/mapper/resource/CheckResourceMapper.java
@@ -1,11 +1,11 @@
 package com.aserto.authroizer.mapper.resource;
 
-import com.aserto.authroizer.mapper.object.ObjectIdMapper;
-import com.aserto.authroizer.mapper.object.ObjectTypeMapper;
-import com.aserto.authroizer.mapper.object.StaticObjectIdMapper;
-import com.aserto.authroizer.mapper.object.StaticObjectTypeMapper;
-import com.aserto.authroizer.mapper.relation.RelationMapper;
-import com.aserto.authroizer.mapper.relation.StaticRelationMapper;
+import com.aserto.authroizer.mapper.check.object.ObjectIdMapper;
+import com.aserto.authroizer.mapper.check.object.ObjectTypeMapper;
+import com.aserto.authroizer.mapper.check.object.StaticObjectIdMapper;
+import com.aserto.authroizer.mapper.check.object.StaticObjectTypeMapper;
+import com.aserto.authroizer.mapper.check.relation.RelationMapper;
+import com.aserto.authroizer.mapper.check.relation.StaticRelationMapper;
 import com.google.protobuf.Value;
 import jakarta.servlet.http.HttpServletRequest;
 
@@ -16,9 +16,6 @@ public class CheckResourceMapper implements ResourceMapper {
     private ObjectTypeMapper objectTypeMapper;
     private ObjectIdMapper objectIdMapper;
     private RelationMapper relationMapper;
-
-//    public CheckResourceMapper() {
-//    }
 
     public CheckResourceMapper(String objectType, String objectId, String relation) {
         this.objectTypeMapper = new StaticObjectTypeMapper(objectType);
@@ -31,31 +28,6 @@ public class CheckResourceMapper implements ResourceMapper {
         this.objectIdMapper = objectIdMapper;
         this.relationMapper = relationMapper;
     }
-//
-//    public void setObjectTypeMapper(ObjectTypeMapper objectTypeMapper) {
-//        this.objectTypeMapper = objectTypeMapper;
-//    }
-//
-//    public void setObjectType(String objectType) {
-//        this.objectTypeMapper = new StaticObjectTypeMapper(objectType);
-//    }
-//
-//    public void setObjectIdMapper(ObjectIdMapper objectIdMapper) {
-//        this.objectIdMapper = objectIdMapper;
-//    }
-//
-//    public void setObjectId(String objectId) {
-//        this.objectIdMapper = new StaticObjectIdMapper(objectId);
-//    }
-//
-//    public void setRelationMapper(RelationMapper relationMapper) {
-//        this.relationMapper = relationMapper;
-//    }
-//
-//    public void setRelation(String relation) {
-//        this.relationMapper = new StaticRelationMapper(relation);
-//    }
-
 
     @Override
     public Map<String, Value> getResource(HttpServletRequest request) throws ResourceMapperError {

--- a/src/main/java/com/aserto/authroizer/mapper/resource/CheckResourceMapper.java
+++ b/src/main/java/com/aserto/authroizer/mapper/resource/CheckResourceMapper.java
@@ -17,10 +17,12 @@ public class CheckResourceMapper implements ResourceMapper {
     private ObjectIdMapper objectIdMapper;
     private RelationMapper relationMapper;
 
+//    public CheckResourceMapper() {
+//    }
 
-    public CheckResourceMapper(String objectType, String objectKey, String relation) {
+    public CheckResourceMapper(String objectType, String objectId, String relation) {
         this.objectTypeMapper = new StaticObjectTypeMapper(objectType);
-        this.objectIdMapper = new StaticObjectIdMapper(objectKey);
+        this.objectIdMapper = new StaticObjectIdMapper(objectId);
         this.relationMapper = new StaticRelationMapper(relation);
     }
 
@@ -29,6 +31,31 @@ public class CheckResourceMapper implements ResourceMapper {
         this.objectIdMapper = objectIdMapper;
         this.relationMapper = relationMapper;
     }
+//
+//    public void setObjectTypeMapper(ObjectTypeMapper objectTypeMapper) {
+//        this.objectTypeMapper = objectTypeMapper;
+//    }
+//
+//    public void setObjectType(String objectType) {
+//        this.objectTypeMapper = new StaticObjectTypeMapper(objectType);
+//    }
+//
+//    public void setObjectIdMapper(ObjectIdMapper objectIdMapper) {
+//        this.objectIdMapper = objectIdMapper;
+//    }
+//
+//    public void setObjectId(String objectId) {
+//        this.objectIdMapper = new StaticObjectIdMapper(objectId);
+//    }
+//
+//    public void setRelationMapper(RelationMapper relationMapper) {
+//        this.relationMapper = relationMapper;
+//    }
+//
+//    public void setRelation(String relation) {
+//        this.relationMapper = new StaticRelationMapper(relation);
+//    }
+
 
     @Override
     public Map<String, Value> getResource(HttpServletRequest request) throws ResourceMapperError {


### PR DESCRIPTION
The check cal only allowed objectType, objectId, and relation to be either strings or mappers. This PR allows users to combine hardcoded strings with mappers to specify object id, type, and relation. The check annotation uses a builder pattern and it also allows users to specify a subject type and id. In this case, an identity manual will be used.

The old check annotation
```java
@PreAuthorize("@aserto.check('group', 'admin', 'member')")
```

The new check annotation
```java
@PreAuthorize("@check.objectType('group').objectId('admin').relation('member').allowed()")
```

check with custom mapper
```java
@PreAuthorize("@check.objectType('group').objectId(@objIdMapper.fromAttribute('id')).relation('member').allowed()")   // we use a custom mapper that extracts the id from the path params

```